### PR TITLE
Fix for an AWS illegal character issue upon certificate upload

### DIFF
--- a/lib/fastlane/plugin/secrets_manager_storage/storage.rb
+++ b/lib/fastlane/plugin/secrets_manager_storage/storage.rb
@@ -233,6 +233,7 @@ module Fastlane
           secret_specific_tags["Name"] = cert_info
             .find { |attribute| attribute.first == "Common Name" }
             .last
+            .gsub(/[^a-zA-Z0-9_ .:\/=+-]/, "")
           expiry = cert_info.find { |attribute| attribute.first == "End Datetime" }.last
         when ".mobileprovision"
           secret_specific_tags[


### PR DESCRIPTION
An example `cert_info` value could be this:

[
  ["User ID", "USERIDGOESHERE"],
  ["Common Name", "Apple Development: Robert Baker (CERTIDGOESHERE)"],
  ["Organisation Unit", "ORG UNIT GOES HERE"],
  ["Organisation", "ORG NAME GOES HERE."],
  ["Country", "COUNTRY CODE"],
  ["Start Datetime", "2024-11-28 16:51:51 UTC"],
  ["End Datetime", "2025-11-28 16:51:50 UTC"]
]

"Common Name" in this case has parentheses, and was failing at this step as AWS rejected it with this error:

`[16:28:39]: Request rejected by the downstream tagging service. Please check that you're only using allowed characters.`

According to the docs: https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_TagResource.html

> Keys and values can only contain alphanumeric characters, spaces, and any of the following: _.:/=+@-

This change cleanses this input